### PR TITLE
nofication is not arn but topic name

### DIFF
--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -35,7 +35,7 @@ class Config(object):
 
     @property
     def notification(self) -> str:
-        return 'arn:aws:sns:ap-northeast-1:445285296882:acme-cert-updater-test-UpdateTopic-141WK4DP5P40E'
+        return 'acme-cert-updater-test-UpdateTopic-141WK4DP5P40E'
 
 def test_certonly():
     cfg = Config()


### PR DESCRIPTION
the definition of SNSPublishMessagePolicy is here.
https://docs.aws.amazon.com/serverlessrepo/latest/devguide/using-aws-sam.html

```json
        "Statement": [
          {
            "Effect": "Allow",
            "Action": [
              "sns:Publish"
            ],
            "Resource": {
              "Fn::Sub": [
                "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}",
                {
                  "topicName": {
                    "Ref": "TopicName"
                  }
                }
              ]
            }
          }
        ]
```