### PR TITLE
remove botocore from the archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ help: ## Show this text.
 build: ## Build SAM application.
 	pipenv lock -r > updater/requirements.txt
 	sam build --use-container
+	cp README.md .aws-sam/build/
+	cp LICENSE .aws-sam/build/
+
+	# boto3 and botocore are pre-installed in Python 3.7 runtime
+	rm -r .aws-sam/build/AcmeCertUpdater/boto3*
+	rm -r .aws-sam/build/AcmeCertUpdater/botocore*
 
 test: ## run tests
 	python -m pytest tests/ -v
@@ -14,11 +20,7 @@ test: ## run tests
 validate: ## validate SAM template
 	sam validate
 
-release: ## Release the application to AWS Serverless Application Repository
-	pipenv lock -r > updater/requirements.txt
-	sam build --use-container
-	cp README.md .aws-sam/build/
-	cp LICENSE .aws-sam/build/
+release: build ## Release the application to AWS Serverless Application Repository
 	sam package \
 		--template-file .aws-sam/build/template.yaml \
 		--output-template-file .aws-sam/build/packaged.yaml \

--- a/Pipfile
+++ b/Pipfile
@@ -11,11 +11,15 @@ aws-sam-cli = "*"
 mypy = "*"
 
 [packages]
-boto3 = "*"
+# pre-install SDK version
+# https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+boto3 = "==1.9.42"
+botocore = "==1.12.42"
+
 configobj = "*"
 certbot = "*"
 certbot-dns-route53 = "*"
 pyyaml = ">=4.2b1"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "87fda24a54397e1583d048d6c3874c43e6b85205859798f8667828dc358bd21a"
+            "sha256": "0b4f5f0938fa75304955b8f43e859791f63cdfa8c49b8fa6de9073124f8d23c5"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -32,18 +32,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:19a77d8ecb05d87123e88a65cba49cdbc8c66717ced21c2093a6f091492c22da",
-                "sha256:e184590781c127358c2d9ae1eab6607441d92fbddd88ba08b891b8c14d0bbfff"
+                "sha256:02e5c1b85a8b22a92f612daf2d1eea305818076b24ce02878b85e92d9ae0082e",
+                "sha256:0e625e147eafdaf9b6c649391059156517daa579ff231e618bd3372e16dacd41"
             ],
             "index": "pypi",
-            "version": "==1.9.205"
+            "version": "==1.9.42"
         },
         "botocore": {
             "hashes": [
-                "sha256:0d6290f725a69a5950785fb058c2405e438674011eff7c11ce192b561b3c9aa6",
-                "sha256:e9452a8e48aea82157e846eb8ec2e8e57f52366ba3362ec5128ecff2c8b52e2f"
+                "sha256:0e495bcf2e474b82da7938b35ad2f71e28384c246b47ca131779f736621da504",
+                "sha256:a890509fb7625fc5c86475db58ac7db489539000cecab349d8eabf5e5777e363"
             ],
-            "version": "==1.12.205"
+            "index": "pypi",
+            "version": "==1.12.42"
         },
         "certbot": {
             "hashes": [
@@ -144,11 +145,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
-                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
-                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "version": "==0.14"
+            "version": "==0.15.2"
         },
         "future": {
             "hashes": [
@@ -264,10 +265,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
-                "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
+                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
+                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
             ],
-            "version": "==0.2.1"
+            "version": "==0.1.13"
         },
         "six": {
             "hashes": [
@@ -278,11 +279,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.25.3"
+            "version": "==1.24.3"
         },
         "zope.component": {
             "hashes": [
@@ -447,18 +448,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:19a77d8ecb05d87123e88a65cba49cdbc8c66717ced21c2093a6f091492c22da",
-                "sha256:e184590781c127358c2d9ae1eab6607441d92fbddd88ba08b891b8c14d0bbfff"
+                "sha256:02e5c1b85a8b22a92f612daf2d1eea305818076b24ce02878b85e92d9ae0082e",
+                "sha256:0e625e147eafdaf9b6c649391059156517daa579ff231e618bd3372e16dacd41"
             ],
             "index": "pypi",
-            "version": "==1.9.205"
+            "version": "==1.9.42"
         },
         "botocore": {
             "hashes": [
-                "sha256:0d6290f725a69a5950785fb058c2405e438674011eff7c11ce192b561b3c9aa6",
-                "sha256:e9452a8e48aea82157e846eb8ec2e8e57f52366ba3362ec5128ecff2c8b52e2f"
+                "sha256:0e495bcf2e474b82da7938b35ad2f71e28384c246b47ca131779f736621da504",
+                "sha256:a890509fb7625fc5c86475db58ac7db489539000cecab349d8eabf5e5777e363"
             ],
-            "version": "==1.12.205"
+            "index": "pypi",
+            "version": "==1.12.42"
         },
         "certifi": {
             "hashes": [
@@ -525,11 +527,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
-                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
-                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "version": "==0.14"
+            "version": "==0.15.2"
         },
         "flask": {
             "hashes": [
@@ -821,10 +823,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
-                "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
+                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
+                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
             ],
-            "version": "==0.2.1"
+            "version": "==0.1.13"
         },
         "serverlessrepo": {
             "hashes": [
@@ -878,11 +880,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.25.3"
+            "version": "==1.24.3"
         },
         "wcwidth": {
             "hashes": [

--- a/updater/requirements.txt
+++ b/updater/requirements.txt
@@ -1,8 +1,8 @@
 -i https://pypi.org/simple
 acme==0.37.1
 asn1crypto==0.24.0
-boto3==1.9.205
-botocore==1.12.205
+boto3==1.9.42
+botocore==1.12.42
 certbot-dns-route53==0.37.1
 certbot==0.37.1
 certifi==2019.6.16
@@ -11,7 +11,7 @@ chardet==3.0.4
 configargparse==0.14.0
 configobj==5.0.6
 cryptography==2.7
-docutils==0.14
+docutils==0.15.2
 future==0.17.1
 idna==2.8
 jmespath==0.9.4
@@ -26,9 +26,9 @@ pytz==2019.2
 pyyaml==5.1.2
 requests-toolbelt==0.9.1
 requests[security]==2.22.0
-s3transfer==0.2.1
+s3transfer==0.1.13
 six==1.12.0
-urllib3==1.25.3 ; python_version >= '3.4'
+urllib3==1.24.3 ; python_version >= '3.4'
 zope.component==4.5
 zope.deferredimport==4.3.1
 zope.deprecation==4.4.0


### PR DESCRIPTION
boto3 and botocore are pre-installed in Python 3.7 runtime.
so we don't need them in our archive.
