### PR TITLE
add --no-random-sleep-on-renew option, fixes #126

### DIFF
--- a/updater/app.py
+++ b/updater/app.py
@@ -165,6 +165,7 @@ def renew(config) -> None:
         input_array = [
             'renew',
             '--noninteractive',
+            '--no-random-sleep-on-renew',
             '--agree-tos',
             '--email', config.email,
             '--dns-route53',


### PR DESCRIPTION
we don't need to sleep because Amazon EventBridge does it.