### PR TITLE
introduce custom resource

### DIFF
--- a/deploy-shogo82148.sh
+++ b/deploy-shogo82148.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# deploy the author's AWS Account for testing
+
+set -uex
+
+CURRENT=$(cd "$(dirname "$0")" && pwd)
+
+cd "$CURRENT"
+make build
+
+sam package \
+    --region ap-northeast-1 \
+    --template-file "$CURRENT/.aws-sam/build/template.yaml" \
+    --output-template-file "$CURRENT/.aws-sam/build/packaged-test.yaml" \
+    --s3-bucket shogo82148-test \
+    --s3-prefix acme-cert-updater/resource
+
+sam deploy \
+    --template "$CURRENT/.aws-sam/build/packaged-test.yaml" \
+    --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM \
+    --stack-name acme-cert-updater-deployment-test \
+    --parameter-overrides Domains=shogo82148.com Email=shogo82148@gmail.com Environment=staging BucketName=shogo82148-test Prefix=acme-cert-updater/cert HostedZone=Z1TR8BQNS8S1I7 LogLevel=DEBUG

--- a/template.yaml
+++ b/template.yaml
@@ -128,6 +128,12 @@ Resources:
               Resource:
                 - !Sub arn:aws:route53:::hostedzone/${HostedZone}
 
+  Certificate:
+    Type: Custom::Certificate
+    Properties:
+      ServiceToken: !GetAtt AcmeCertUpdater.Arn
+      Input: !Sub '{"domains":"${Domains}","cert_name":"${CertName}"}'
+
 Outputs:
   Arn:
     Description: the arn of updater AWS Lambda function

--- a/template.yaml
+++ b/template.yaml
@@ -132,7 +132,8 @@ Resources:
     Type: Custom::Certificate
     Properties:
       ServiceToken: !GetAtt AcmeCertUpdater.Arn
-      Input: !Sub '{"domains":"${Domains}","cert_name":"${CertName}"}'
+      domains: !Ref Domains
+      cert_name: !Ref CertName
 
 Outputs:
   Arn:

--- a/updater/app.py
+++ b/updater/app.py
@@ -464,10 +464,10 @@ def needs_init(config) -> bool:
         return True
     return False
 
-def lambda_handler(event, context): # pylint: disable=unused-argument
+def lambda_handler(event: object, context: object): # pylint: disable=unused-argument
     """entry point of AWS Lambda"""
 
-    if event in "RequestType":
+    if "RequestType" in event:
         # it looks like a request from AWS Lambda-backed custom resources
         handle_cfn_custom_resource(event)
     else:


### PR DESCRIPTION
fixes https://github.com/shogo82148/acme-cert-updater/issues/127

> Custom resources enable you to write custom provisioning logic in templates that AWS CloudFormation runs anytime you create, update (if you changed the custom resource), or delete stacks.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/walkthrough-custom-resources-lambda-lookup-amiids.html

Custom resources also enable we to run certbot when  AWS CloudFormation runs create, update, or delete stacks.