### PR TITLE
migrate set-output command

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -34,7 +34,7 @@ jobs:
           # boto3 and botocore are updated very often, so ignore them
           diff <(cat updater/requirements.txt | grep -v -E 'boto(3|core)') \
             <(cat updater/requirements_new.txt | grep -v -E 'boto(3|core)') && true
-          echo "::set-output name=result::$?"
+          echo "result=$?" >> "$GITHUB_OUTPUT"
           mv updater/requirements_new.txt updater/requirements.txt
 
       - name: commit


### PR DESCRIPTION
see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/